### PR TITLE
Check pip availability before running ensurepip

### DIFF
--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -84,7 +84,9 @@ chmod +x $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR python
 
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
-./python -m ensurepip
+if ! ./python -c "import pip" 2>/dev/null; then
+  ./python -m ensurepip
+fi
 ./python -m pip install --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
 
 echo "Install OpenSSL certificates"

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -51,7 +51,9 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR pyth
 
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
-./python -m ensurepip
+if ! ./python -c "import pip" 2>/dev/null; then
+  ./python -m ensurepip
+fi
 ./python -m pip install --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -138,7 +138,11 @@ New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$Pyt
 Write-Host "Install and upgrade Pip"
 $Env:PIP_ROOT_USER_ACTION = "ignore"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
+cmd.exe /c "$PythonExePath -c ""import pip"""
+if ($LASTEXITCODE -ne 0) {
+    cmd.exe /c "$PythonExePath -m ensurepip"
+}
+cmd.exe /c "$PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during pip installation / upgrade"
 }

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -138,7 +138,7 @@ New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$Pyt
 Write-Host "Install and upgrade Pip"
 $Env:PIP_ROOT_USER_ACTION = "ignore"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -c ""import pip"""
+cmd.exe /c "$PythonExePath -c ""import pip"" 2>NUL"
 if ($LASTEXITCODE -ne 0) {
     cmd.exe /c "$PythonExePath -m ensurepip"
     if ($LASTEXITCODE -ne 0) {

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -141,6 +141,9 @@ $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
 cmd.exe /c "$PythonExePath -c ""import pip"""
 if ($LASTEXITCODE -ne 0) {
     cmd.exe /c "$PythonExePath -m ensurepip"
+    if ($LASTEXITCODE -ne 0) {
+        Throw "Error happened during ensurepip execution"
+    }
 }
 cmd.exe /c "$PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
This pull request improves the robustness of the Python installation scripts across macOS, Linux, and Windows by ensuring that `pip` is only bootstrapped with `ensurepip` if it is not already present. This prevents unnecessary reinstallation and potential errors during setup.